### PR TITLE
ci: Fix artifact name

### DIFF
--- a/.github/actions/build-connector/action.yml
+++ b/.github/actions/build-connector/action.yml
@@ -26,7 +26,7 @@ outputs:
     description: 'Path to the signed connector file (if signed)'
     value: ${{ steps.sign.outputs.connector-path-signed }}
   artifact-name:
-    description: 'Name of the uploaded artifact'
+    description: 'Base name of the uploaded artifact. The actual artifact will be this {name}-signed or {name}-unsigned'
     value: ${{ inputs.artifact-name }}
 runs:
   using: 'composite'

--- a/.github/workflows/powerbi-tests.yml
+++ b/.github/workflows/powerbi-tests.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Download Connector Artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build.outputs.artifact-name }}
+          name: ${{ needs.build.outputs.artifact-name }}-unsigned
           path: .
 
       - name: Set Common Paths
@@ -176,7 +176,7 @@ jobs:
           $timestamp = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
           $outputFile = "test-results-$timestamp.txt"
           $output | Out-File -FilePath $outputFile -Encoding UTF8
-          
+
           # Save the output filename for the next step
           echo "output-file=$outputFile" >> $env:GITHUB_OUTPUT
 
@@ -203,12 +203,12 @@ jobs:
           if ($tableStartIndex -gt -1) {
             $stepSummary += "## PowerQuery SDK Test Results`n`n"
             $stepSummary += "``````text`n"
-            
+
             # Add everything from the table header onwards
             for ($i = $tableStartIndex; $i -lt $lines.Count; $i++) {
               $stepSummary += $lines[$i] + "`n"
             }
-            
+
             $stepSummary += "``````"
           } else {
             $stepSummary += "## PowerQuery SDK Test Results`n`n"


### PR DESCRIPTION
Test workflow was not updated after we've added signing, it relied on artifact name staying the same. However, we've added two versions, `-signed` and `-unsigned` so we need to use the correct on in the test.